### PR TITLE
Check team membership before actioning backport by comment

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -48,7 +48,7 @@ jobs:
           ORG="${ORG_TEAM%%/*}"
           TEAM="${ORG_TEAM##*/}"
           if ! gh api "orgs/${ORG}/teams/${TEAM}/memberships/${COMMENT_USER}" --silent; then
-            echo "::error::User ${COMMENT_USER} is not a member of ${ORG}/${TEAM"
+            echo "::error::User ${COMMENT_USER} is not a member of ${ORG}/${TEAM}"
             exit 1
           fi
           echo "User ${COMMENT_USER} is a member of ${ORG_TEAM}"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -48,7 +48,7 @@ jobs:
           ORG="${ORG_TEAM%%/*}"
           TEAM="${ORG_TEAM##*/}"
           if ! gh api "orgs/${ORG}/teams/${TEAM}/memberships/${COMMENT_USER}" --silent; then
-            echo "::error::User ${COMMENT_USER} is not a member of ${ORG_TEAM}"
+            echo "::error::User ${COMMENT_USER} is not a member of ${ORG}/${TEAM"
             exit 1
           fi
           echo "User ${COMMENT_USER} is a member of ${ORG_TEAM}"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -6,19 +6,21 @@ on:
         required: false
         type: string
         default: 'stable'
-
+      backport-team:
+        required: true
+        type: string
+        description: 'The org/team-slug allowed to trigger /backport (e.g. my-org/my-team)'
 permissions:
   contents: write
   pull-requests: write
-
 jobs:
   backport:
     name: Backport
     runs-on: ubuntu-latest
     # Only run if:
     #  - triggered by pull request merging, or
-    #  - a label starting with `backport ` is added to a merged PR, or
-    #  - `/backport` commented on a PR by someone other than "Sei Platform / Code Agent" GitHub App.
+    #  - `/backport` commented on a PR by someone other than the bot
+    #    (team membership is verified in a later step)
     if: >
       (
         github.event_name == 'pull_request_target' &&
@@ -36,7 +38,20 @@ jobs:
         with:
           app-id: ${{ secrets.PLATFORM_CODE_AGENT_APP_ID }}
           private-key: ${{ secrets.PLATFORM_CODE_AGENT_APP_PK }}
-
+      - name: Check team membership for /backport comments
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          ORG_TEAM: ${{ inputs.backport-team }}
+          COMMENT_USER: ${{ github.event.comment.user.login }}
+        run: |
+          ORG="${ORG_TEAM%%/*}"
+          TEAM="${ORG_TEAM##*/}"
+          if ! gh api "orgs/${ORG}/teams/${TEAM}/memberships/${COMMENT_USER}" --silent; then
+            echo "::error::User ${COMMENT_USER} is not a member of ${ORG_TEAM}"
+            exit 1
+          fi
+          echo "User ${COMMENT_USER} is a member of ${ORG_TEAM}"
       - uses: actions/checkout@v6
       - name: Create backport pull requests
         uses: korthout/backport-action@v4.1.0


### PR DESCRIPTION
Require the commenter of post merge backport to be a member of a team.