### PR TITLE
Add reusable goreleaser-release workflow

### DIFF
--- a/.github/workflows/goreleaser-release.yml
+++ b/.github/workflows/goreleaser-release.yml
@@ -1,0 +1,108 @@
+name: GoReleaser
+run-name: UCI / GoReleaser Release
+on:
+  workflow_call:
+    inputs:
+      go-version:
+        description: "Go version. Mutually exclusive with go-version-file."
+        required: false
+        type: string
+        default: ''
+      go-version-file:
+        description: "Path to go.mod (or other) for Go version detection. Mutually exclusive with go-version."
+        required: false
+        type: string
+        default: ''
+      goreleaser-version:
+        description: "GoReleaser version expression (e.g. '~> v2', 'v2.4.4', 'latest', 'nightly')."
+        required: false
+        type: string
+        default: '~> v2'
+      args:
+        description: "Arguments passed to goreleaser."
+        required: false
+        type: string
+        default: 'release --clean'
+      working-directory:
+        description: "Repo subdirectory containing .goreleaser.yaml."
+        required: false
+        type: string
+        default: '.'
+      ref:
+        description: "Git ref to checkout. Empty checks out the triggering ref."
+        required: false
+        type: string
+        default: ''
+      checkout-latest-tag:
+        description: "After checkout, switch to the latest tag (sorted by v:refname). Useful when triggered by workflow_run."
+        required: false
+        type: boolean
+        default: false
+      submodules:
+        description: "Submodule checkout option, passed to actions/checkout (false | true | recursive)."
+        required: false
+        type: string
+        default: 'false'
+      fetch-depth:
+        description: "Fetch depth for actions/checkout. 0 = full history (required by GoReleaser to compute changelog)."
+        required: false
+        type: number
+        default: 0
+      runs-on:
+        description: "Runner label."
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+      prebuild-script:
+        description: "Inline shell run after checkout, before goreleaser. Use for system deps or per-repo prep."
+        required: false
+        type: string
+        default: ''
+    secrets:
+      UCI_GITHUB_TOKEN:
+        description: "Optional override for the token used to create the GitHub Release. Defaults to github.token."
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    name: Publish
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: ${{ inputs.fetch-depth }}
+          ref: ${{ inputs.ref }}
+          submodules: ${{ inputs.submodules }}
+      - name: Checkout latest tag
+        if: inputs.checkout-latest-tag
+        run: |
+          git fetch origin --tags --force
+          LATEST_TAG=$(git tag --sort=-v:refname | head -n 1)
+          if [[ -z "${LATEST_TAG}" ]]; then
+            echo "::error::no tags present in repo"
+            exit 1
+          fi
+          echo "Checking out latest tag: ${LATEST_TAG}"
+          git checkout "${LATEST_TAG}"
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ inputs.go-version }}
+          go-version-file: ${{ inputs.go-version-file }}
+      - name: Run prebuild script
+        if: inputs.prebuild-script != ''
+        working-directory: ${{ inputs.working-directory }}
+        run: ${{ inputs.prebuild-script }}
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: ${{ inputs.goreleaser-version }}
+          args: ${{ inputs.args }}
+          workdir: ${{ inputs.working-directory }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN || github.token }}

--- a/.github/workflows/goreleaser-release.yml
+++ b/.github/workflows/goreleaser-release.yml
@@ -92,7 +92,9 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ inputs.go-version }}
-          go-version-file: ${{ inputs.go-version-file }}
+          # When neither version input is given, default to <working-directory>/go.mod
+          # so version auto-detection works for callers building in a subdirectory.
+          go-version-file: ${{ inputs.go-version-file != '' && inputs.go-version-file || (inputs.go-version == '' && format('{0}/go.mod', inputs.working-directory) || '') }}
       - name: Run prebuild script
         if: inputs.prebuild-script != ''
         working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
Adds a \`workflow_call\`-only \`.github/workflows/goreleaser-release.yml\` that runs GoReleaser against a caller repo. Generalises the standalone \`goreleaser.yml\` currently used in seictl into a maintained, versioned uci primitive any sei-protocol repo can call.

Inputs cover the variation we see across consumers: \`go-version\` / \`go-version-file\`, \`goreleaser-version\`, \`args\`, \`working-directory\`, \`ref\`, \`checkout-latest-tag\`, \`submodules\`, \`fetch-depth\`, \`runs-on\`, \`prebuild-script\`. Token defaults to \`github.token\`; an \`UCI_GITHUB_TOKEN\` secret may override.

Refs PLT-41.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it introduces a new release-publishing workflow with `contents: write` permissions and configurable refs/tags, which could affect how releases are produced if misused or misconfigured.
> 
> **Overview**
> Introduces a new reusable GitHub Actions workflow, `.github/workflows/goreleaser-release.yml`, intended to be invoked via `workflow_call` to publish releases using GoReleaser.
> 
> The workflow is parameterized for Go/GoReleaser versions, args, working directory, checkout ref/tag behavior (including an optional "checkout latest tag" step), submodules, fetch depth, runner selection, and an optional prebuild script; it publishes using `contents: write` and supports overriding the release token via `UCI_GITHUB_TOKEN` (defaulting to `github.token`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a19a886a9433e5c23aa84ca6932ec28aa22f0d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->