### PR TITLE
Add version and release_created outputs to release-publish

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -6,6 +6,13 @@ on:
         required: false
         type: string
         default: ${{ format('["{0}"]', github.event.repository.default_branch) }}
+    outputs:
+      version:
+        description: "Version from version.json (e.g. v1.2.3). Empty if version.json is absent."
+        value: ${{ jobs.releaser.outputs.version }}
+      release_created:
+        description: "'true' if a new GitHub Release was created in this run, else 'false'."
+        value: ${{ jobs.releaser.outputs.release_created }}
     secrets:
       UCI_GITHUB_TOKEN:
         required: false
@@ -14,6 +21,9 @@ jobs:
   releaser:
     name: Publish
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      release_created: ${{ steps.release.outputs.id != '' && 'true' || 'false' }}
     steps:
       - uses: actions/checkout@v6
       - id: version


### PR DESCRIPTION
## What
Two additive `workflow_call` outputs on the reusable `release-publish.yml`:
- `version` — the version from `version.json` (e.g. `v1.2.3`)
- `release_created` — `'true'` only when this run actually created a GitHub Release

## Why
A caller currently has no reliable way to hand the just-published version to a downstream job. To attach release artifacts (e.g. GoReleaser binaries), today's only options are:
- the **tag-push trigger** — suppressed when the release is created with `GITHUB_TOKEN` (GitHub doesn't fire workflows from token-created tags), so it never runs; or
- **`checkout-latest-tag`** — picks the globally-highest tag, which is wrong for repos that release from multiple `release/**` branches (it can grab a parallel line or an RC).

With these outputs a caller can chain the build/release job to the **exact** tag, and only when a release was actually cut:

```yaml
jobs:
  publish:
    uses: sei-protocol/uci/.github/workflows/release-publish.yml@<tag>
  goreleaser:
    needs: publish
    if: needs.publish.outputs.release_created == 'true'
    uses: sei-protocol/uci/.github/workflows/goreleaser-release.yml@<tag>
    with:
      ref: ${{ needs.publish.outputs.version }}
```

## Impact
Purely additive — the outputs are ignored by consumers that don't reference them, so the repos pinned to older tags are unaffected until they opt in. No change to release-creation behaviour.