### PR TITLE
xreview: address Cursor Bugbot findings on #46

### DIFF
--- a/xreview/driver/__main__.py
+++ b/xreview/driver/__main__.py
@@ -52,11 +52,16 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def _write_verdict(path: str, result: RunResult) -> None:
-    """Write the human-readable verdict for the caller to post or summarize."""
-    if result.verdict is not None:
-        body = result.verdict.text
-    else:
-        body = f"sei-droid xreview produced no verdict (exit {int(result.exit_code)})."
+    """Write the verdict text for the caller to post — only on a real verdict.
+
+    On a no-verdict outcome (NO_VERDICT / TIMEOUT / TURN_FAILED) the file is
+    left absent, so the caller distinguishes "ready to post" from "nothing to
+    post" by file existence and never upserts a placeholder over a prior good
+    verdict. The exit code still carries the outcome for the caller to surface.
+    """
+    if result.verdict is None:
+        return
+    body = result.verdict.text
     if not body.endswith("\n"):
         body += "\n"
     with open(path, "w", encoding="utf-8") as handle:

--- a/xreview/driver/tests/selftest.py
+++ b/xreview/driver/tests/selftest.py
@@ -307,6 +307,43 @@ def test_verdict_parsing_requires_decision_key() -> None:
     )
 
 
+# ── Tests: _write_verdict file existence == verdict produced ──────────────
+
+
+def test_write_verdict_only_on_real_verdict() -> None:
+    """A no-verdict run leaves the out-file absent, so the action never upserts
+    a placeholder over a prior good verdict; a real verdict writes the text."""
+    import os
+    import tempfile
+
+    from driver.__main__ import _write_verdict
+    from driver.driver import RunResult
+    from driver.errors import ExitCode
+    from driver.verdict import Verdict
+
+    d = tempfile.mkdtemp()
+
+    real = os.path.join(d, "verdict-real.md")
+    verdict = Verdict(
+        assistant_item_id="a1",
+        text="Reviewed the change; approve.",
+        structured={"decision": "approve"},
+    )
+    _write_verdict(real, RunResult(exit_code=ExitCode.OK, verdict=verdict))
+    check(
+        "write-verdict: a real verdict writes the file with its text",
+        os.path.exists(real)
+        and "approve" in open(real, encoding="utf-8").read(),
+    )
+
+    absent = os.path.join(d, "verdict-none.md")
+    _write_verdict(absent, RunResult(exit_code=ExitCode.NO_VERDICT, verdict=None))
+    check(
+        "write-verdict: a no-verdict run leaves the file absent (no placeholder)",
+        not os.path.exists(absent),
+    )
+
+
 def main() -> int:
     for test in (
         test_structured_first_settle_no_nudge,
@@ -316,6 +353,7 @@ def main() -> int:
         test_stale_state_not_renudged_when_budget_remains,
         test_distinct_new_messages_each_consume_budget,
         test_verdict_parsing_requires_decision_key,
+        test_write_verdict_only_on_real_verdict,
     ):
         test()
     print()

--- a/xreview/tools/action.yml
+++ b/xreview/tools/action.yml
@@ -79,6 +79,7 @@ runs:
         echo "token=$token" >> "$GITHUB_OUTPUT"
 
     - name: Drive session + collect verdict
+      id: drive
       shell: bash
       env:
         DRIVER_PYTHON: ${{ steps.runtime.outputs.python }}
@@ -91,7 +92,8 @@ runs:
       run: |
         set -euo pipefail
         # Create exactly ONE managed sei-droid session, drive it, write the
-        # verdict to verdict.md, and DELETE the session on exit AND on
+        # verdict to verdict.md (ONLY when a real verdict is produced — the
+        # driver writes no placeholder), and DELETE the session on exit AND on
         # SIGTERM/SIGINT so a cancelled run leaves no live session. State
         # lives under RUNNER_TEMP (the generic runner has no /var/lib write).
         # Fail-closed: anything other than the exact opt-in 'false' runs dry.
@@ -100,14 +102,33 @@ runs:
         args=("$REPO" "$PR" --out verdict.md)
         if [ "$DRY_RUN" != "false" ]; then args+=(--dry-run); fi
         if [ -n "${TRIGGER_ID:-}" ]; then args+=(--trigger-id "$TRIGGER_ID"); fi
+        set +e
         PYTHONPATH="$GITHUB_ACTION_PATH/.." \
         XREVIEW_STATE_DIR="$RUNNER_TEMP/seidroid-state" \
           "$DRIVER_PYTHON" -m driver "${args[@]}"
+        rc=$?
+        set -e
+        # Downstream gates on whether a verdict was PRODUCED (verdict.md
+        # non-empty), not on the exit code: a teardown-only failure (verdict
+        # produced, DELETE failed) still publishes, and a no-verdict run
+        # (NO_VERDICT/TIMEOUT/TURN_FAILED) never posts a placeholder.
+        if [ -s verdict.md ]; then
+          echo "verdict_produced=true" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning::driver exited $rc but produced a verdict (e.g. a teardown leak); see logs"
+          fi
+        else
+          echo "verdict_produced=false" >> "$GITHUB_OUTPUT"
+          echo "::error::driver produced no verdict (exit $rc)"
+          exit "$rc"
+        fi
 
     - name: Post verdict (sticky upsert)
-      # Fail-closed: post ONLY on the exact opt-in 'false' (real-post mode), and
-      # only when the drive step produced a verdict (implicit success()).
-      if: ${{ inputs.dry_run == 'false' }}
+      # Post ONLY in real-post mode AND only when a real verdict was produced
+      # (drive step's verdict_produced). Keying on verdict_produced, not the
+      # exit code, so a teardown-only failure still posts a valid verdict and a
+      # no-verdict run never upserts a placeholder over a prior good comment.
+      if: ${{ inputs.dry_run == 'false' && steps.drive.outputs.verdict_produced == 'true' }}
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}

--- a/xreview/tools/seidroid-xreview.yml
+++ b/xreview/tools/seidroid-xreview.yml
@@ -11,12 +11,6 @@ on:
 # Least privilege: nothing by default. Each job adds only what it needs.
 permissions: {}
 
-# Exactly one review per PR. A newer trigger cancels an in-flight one (latest wins,
-# never two posters). The driver traps cancellation and DELETEs its omnigent session.
-concurrency:
-  group: seidroid-xreview-${{ github.event.issue.number }}
-  cancel-in-progress: true
-
 jobs:
   guard:
     # Cheap allowlist + command parse on a hosted runner, no secrets, before any
@@ -42,17 +36,22 @@ jobs:
         run: |
           set -euo pipefail
           cmd="$(printf '%s' "$BODY" | tr -d '\r')"
-          # Trigger on a LINE reading exactly `seidroid xreview` (optionally
-          # `--dry-run`); grep is line-oriented, so the command may sit inside a
-          # longer comment as long as one line matches on its own.
-          if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*seidroid[[:space:]]+xreview([[:space:]]+--dry-run)?[[:space:]]*$'; then
+          # Match a LINE reading exactly `seidroid xreview` (optionally
+          # `--dry-run`) and CAPTURE it; grep is line-oriented, so the command
+          # may sit inside a longer comment as long as one line matches on its
+          # own. The captured line — not the whole body — is what the --dry-run
+          # check below reads, so prose mentioning `--dry-run` elsewhere in the
+          # comment cannot force dry-run.
+          cmdline="$(printf '%s\n' "$cmd" | grep -m1 -E '^[[:space:]]*seidroid[[:space:]]+xreview([[:space:]]+--dry-run)?[[:space:]]*$' || true)"
+          if [ -z "$cmdline" ]; then
             echo "should_run=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "should_run=true" >> "$GITHUB_OUTPUT"
-          # dry-run = comment flag OR repo default. Unset repo var -> TRUE (fail safe).
+          # dry-run = the flag ON THE COMMAND LINE, or the repo default. Unset
+          # repo var -> TRUE (fail safe).
           dry="${REPO_DRY_RUN:-true}"
-          if printf '%s' "$cmd" | grep -qE -- '--dry-run'; then dry=true; fi
+          if printf '%s' "$cmdline" | grep -qE -- '--dry-run'; then dry=true; fi
           echo "dry_run=$dry" >> "$GITHUB_OUTPUT"
           echo "pr_number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
           # The comment id becomes the driver's per-trigger run key, so a
@@ -63,6 +62,14 @@ jobs:
   xreview:
     needs: guard
     if: needs.guard.outputs.should_run == 'true'
+    # Exactly one review per PR: a newer `seidroid xreview` cancels an in-flight
+    # one (latest wins, never two posters); the driver traps cancellation and
+    # DELETEs its session. Job-level (not workflow-level) on purpose — the group
+    # is entered ONLY when a real command runs, so an unrelated PR comment (which
+    # skips the guard) never cancels a review that is mid-flight.
+    concurrency:
+      group: seidroid-xreview-${{ github.event.issue.number }}
+      cancel-in-progress: true
     # Org ARC scale set, in-cluster. It reaches omnigent over the ClusterIP
     # Service and mints its bearer with the omnigent client_credentials grant,
     # using a repo/environment-scoped GitHub secret as the client secret.


### PR DESCRIPTION
## What

Addresses [Cursor Bugbot's findings](https://github.com/sei-protocol/uci/pull/46) on #46. Bugbot raised 5; **4 are real** and fixed here, all in the comment-workflow / composite-action layer (which had not run in CI at merge time). The 5th — "shared run key on re-trigger" — was already resolved in #46's review round by wiring `--trigger-id` from the comment id, so it is stale.

| # | Sev | Finding | Fix |
|---|-----|---------|-----|
| 1 | High | Any PR comment cancelled an in-flight review — workflow-level `concurrency` on the issue number + `cancel-in-progress`, but the workflow triggers on every `issue_comment`, so an unrelated comment cancelled a running `xreview` (which then skipped) | Move `concurrency` to the **`xreview` job** — the group is entered only when a real `seidroid xreview` command runs, so unrelated comments (which skip the guard) never cancel a mid-flight review |
| 2 | High | A failed review could post a placeholder — the sticky-post step's explicit `if` replaced the implicit `success()` gate, so after a non-zero driver exit it could upsert a "no verdict" placeholder over a prior good comment | Driver writes `verdict.md` **only on a real verdict**; the drive step exports `verdict_produced`; posting gates on that, not the exit code |
| 3 | Medium | A teardown-only failure blocked posting a valid verdict (`TEARDOWN_LEAK` overwrites `OK`) | Same gate: `verdict_produced` means a produced verdict still posts even if session `DELETE` failed |
| 4 | Medium | `--dry-run` was matched against the whole comment body, so prose mentioning it forced dry-run | Match `--dry-run` on the **captured command line** only |

## Verification

Adds a selftest for the write-verdict / file-existence contract (a no-verdict run leaves `verdict.md` absent so the action never posts a placeholder). Selftest green (20 existing + 2 new); `ruff check` + `ruff format --check` + YAML parse clean.

Still ships dry-run by default; the accepted-risk gate (server-side shell gate before real posts / untrusted content) from #46 is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)