### PR TITLE
xreview: remove dry-run

### DIFF
--- a/.github/seidroid/README.md
+++ b/.github/seidroid/README.md
@@ -9,7 +9,7 @@ publishes. The reusable *workflows* that run these features live in `.github/wor
 | Feature | What it is | Trigger |
 |---|---|---|
 | [`auto-review/`](auto-review/) | The workflow-driven seidroid[bot] helpers and their base prompts: an automatic three-pass PR review (OpenAI Codex ∥ Cursor → Claude synthesis, posting one PR review + an `AI Review` check) and the conversational `@seidroid` assistant. Prompts: `scout.md`, `review.md`, `assistant.md`. | `pull_request` (review); `@seidroid` mention (assistant) |
-| [`xreview/`](xreview/) | On-demand, sandbox-backed deep review. Drives the `sei-droid` agent inside a managed omnigent Kubernetes sandbox with a real `git`/`gh` toolchain, so it can build, test, and inspect the tree before returning one structured verdict. A reusable workflow (`.github/workflows/seidroid-xreview.yml`) plus a Python session driver. Ships dry-run by default. | `seidroid xreview` PR comment |
+| [`xreview/`](xreview/) | On-demand, sandbox-backed deep review. Drives the `sei-droid` agent inside a managed omnigent Kubernetes sandbox with a real `git`/`gh` toolchain, so it can build, test, and inspect the tree before returning one structured verdict. A reusable workflow (`.github/workflows/seidroid-xreview.yml`) plus a Python session driver. | `seidroid xreview` PR comment |
 
 The difference between the two review paths is the engine: `auto-review` passes the diff to
 models from inside the Actions runner and runs on every push; `xreview` drives a full agent

--- a/.github/seidroid/xreview/README.md
+++ b/.github/seidroid/xreview/README.md
@@ -24,7 +24,7 @@ sandbox and a minute of wall-clock, so it is opt-in per PR rather than automatic
 - `.github/workflows/seidroid-xreview.yml` — the **reusable workflow** this feature
   publishes (alongside `ai-review`/`ai-assistant`). On a `seidroid xreview` comment it runs
   the trusted-commenter guard, fetches the driver at the caller's `uci-ref`, mints the
-  omnigent bearer, drives the review, and posts the verdict (or, in dry-run, writes it to the
+  omnigent bearer, drives the review, and posts the verdict
   job summary). Callers reach it with `uses:`.
 - `driver/` — the session driver the reusable workflow runs. Creates exactly one managed
   `sei-droid` session, drives it through a review turn, auto-resolves the agent's permission
@@ -42,14 +42,14 @@ sandbox and a minute of wall-clock, so it is opt-in per PR rather than automatic
 1. A trusted commenter writes `seidroid xreview` on a PR.
 2. The trigger workflow's `guard` job (hosted runner, no secrets) checks the comment author
    is `OWNER`/`MEMBER`/`COLLABORATOR` and that the command line is exactly `seidroid xreview`
-   (optionally `--dry-run`), then resolves the dry-run flag.
+   as a whole line, so a comment that merely quotes or discusses it does not trigger.
 3. The reusable workflow's `xreview` job runs on the `uci-default` org ARC scale set,
    in-cluster. It fetches the driver at `uci-ref`, mints an omnigent bearer with the
    client-credentials grant, and runs the driver.
 4. The driver creates one managed `sei-droid` session, drives the review, and writes the
    verdict to a file only when a real verdict is produced.
 5. In real-post mode the workflow upserts a single `<!-- seidroid-xreview -->` comment on the
-   PR; in dry-run it writes the verdict to the job summary and posts nothing. Either way the
+   PR, and only when a real verdict was produced. Either way the
    session is deleted on exit, including on cancellation.
 
 ## Auth to omnigent
@@ -83,9 +83,8 @@ without that scale set cannot schedule the `xreview` job, and the run never star
    never a moving tag). Bump both to adopt a new xreview release.
 3. Set the `OMNIGENT_M2M_CLIENT_SECRET` repository (or organization) secret to the
    client-credentials secret; `secrets: inherit` in the caller passes it through. It is
-   required even for a dry run: the workflow always mints a bearer; dry-run controls only
+   required for every run: the workflow always mints a bearer to
    whether the verdict is posted.
-4. Leave `vars.SEIDROID_XREVIEW_DRY_RUN` unset (or `true`) until you have watched a real run.
    Setting it to `false` enables posting — and enabling posts grants the sandbox agent a
    write-capable path to the PR. Read "Before enabling real posts" below and keep it unset
    until every item there holds.
@@ -113,8 +112,9 @@ without that scale set cannot schedule the `xreview` job, and the run never star
   to treat the diff, file contents, commit messages, and title/body as untrusted material to
   review, never as directives, and to report an embedded directive as a possible
   prompt-injection finding.
-- **Dry-run is the default.** With the repo variable unset the run posts nothing, which is
-  the safe state for a new wiring.
+- **A run with no verdict posts nothing.** The post step keys on a real verdict having been
+  produced rather than on the exit code, so a failed or timed-out review leaves no comment and
+  a teardown-only failure still posts the verdict it did produce.
 - **One session per trigger, torn down best-effort.** `concurrency` cancels a superseded
   run; the driver traps `SIGTERM`/`SIGINT` and deletes its session on the way out. Under a
   hard kill (a grace period shorter than teardown, a signal mid-DELETE) a session can still
@@ -130,28 +130,24 @@ without that scale set cannot schedule the `xreview` job, and the run never star
   untrusted-content instruction and the server-side shell gate are load-bearing before real
   posting is enabled.
 
-### Before enabling real posts — and before pointing dry-run at untrusted content
+### Before pointing this at untrusted content
 
-Dry-run gates only the *driver's* verdict post. It is **not** a security boundary against the
-agent's own vended `pull_requests: write` token: on untrusted content (e.g. a fork PR) with no
-server-side shell gate, a prompt injection can still drive a real `gh`/`git` write via the
-auto-accepted `Bash` tool **even in dry-run**. So the preconditions below gate two actions —
-(a) setting `SEIDROID_XREVIEW_DRY_RUN=false` to enable real posts, and (b) running the bot at
-all (even dry-run) over untrusted content. Confirm before either:
+The agent holds a vended `pull_requests: write` token and an auto-accepted `Bash` tool, so on
+untrusted content (e.g. a fork PR) with no server-side shell gate a prompt injection can drive
+a real `gh`/`git` write. That risk belongs to running the agent at all, not to whether the
+driver posts its verdict, so there is no review mode that mitigates it. Confirm before pointing
+this at content you do not control:
 
-1. **A successful dry run over first-party content** has completed on that repo — required
-   before enabling real posts.
-2. **A server-side shell gate is enforced** for the `sei-droid` managed agent (or the agent is
+1. **A server-side shell gate is enforced** for the `sei-droid` managed agent (or the agent is
    restricted to a structured read-only tool set), so a prompt-injection string cannot drive
    `gh` / `git push` / `curl`.
-3. **The vended runner token is confirmed minimally scoped** for what review needs, given that
+2. **The vended runner token is confirmed minimally scoped** for what review needs, given that
    an injection would run under it.
-4. **Reviewed content is first-party / trusted, OR item 2 is in place** — this applies in
-   dry-run too, because dry-run does not neuter the vended write token, and the trigger
+3. **Reviewed content is first-party / trusted, OR item 1 is in place** — the trigger
    authenticates the commenter, not the code.
 
-Dry-run over first-party / trusted content is safe to run now. Keep real posting disabled —
-and keep the bot off untrusted content — until the items above hold.
+Running over first-party / trusted content is safe today. Keep the bot off untrusted content
+until the items above hold.
 
 ## Status
 
@@ -159,8 +155,6 @@ The driver has been exercised end-to-end against live PRs: mint, session create,
 launch, the agent reading the PR through the credential bridge, a structured verdict, and
 teardown. The **reusable workflow and its thin caller** are being wired into their first repo
 now; the first `seidroid xreview` comment there is the comment-trigger path's first real test.
-Keep `SEIDROID_XREVIEW_DRY_RUN` unset for that first run and read the job summary before
-enabling posts.
 
 Known gaps for a follow-up: the verdict currently posts as `github-actions[bot]` rather than
 `seidroid[bot]` (posting via the app token, as `ai-review` does, is a later change); and the

--- a/.github/seidroid/xreview/driver/__main__.py
+++ b/.github/seidroid/xreview/driver/__main__.py
@@ -1,4 +1,4 @@
-"""CLI entrypoint: ``python -m driver <repo> <pr> [--dry-run]``."""
+"""CLI entrypoint: ``python -m driver <repo> <pr>``."""
 
 from __future__ import annotations
 
@@ -24,9 +24,7 @@ def main(argv: list[str] | None = None) -> int:
     _install_terminate_handlers()
 
     trigger_id = args.trigger_id or f"manual:{args.repo}#{args.pr}"
-    req = ReviewRequest(
-        repo=args.repo, pr=args.pr, trigger_id=trigger_id, dry_run=args.dry_run
-    )
+    req = ReviewRequest(repo=args.repo, pr=args.pr, trigger_id=trigger_id)
     try:
         result = SessionDriver(cfg).run(req)
     except KeyboardInterrupt:
@@ -90,11 +88,6 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog="seidroid-xreview")
     parser.add_argument("repo", help='"owner/name" of the repository')
     parser.add_argument("pr", type=int, help="pull request number")
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="review only; decline every write/egress and do not post back",
-    )
     parser.add_argument(
         "--out",
         default=None,

--- a/.github/seidroid/xreview/driver/driver.py
+++ b/.github/seidroid/xreview/driver/driver.py
@@ -24,7 +24,7 @@ from .idempotency import (
     finalize_lease,
     record_session,
 )
-from .policy import DecisionFn, Elicitation, best_effort_readonly_policy, dry_run_guard
+from .policy import DecisionFn, Elicitation, best_effort_readonly_policy
 from .verdict import (
     Verdict,
     assistant_message_ids,
@@ -40,7 +40,6 @@ class ReviewRequest:
     repo: str
     pr: int
     trigger_id: str
-    dry_run: bool = False
 
 
 @dataclass
@@ -74,9 +73,7 @@ class SessionDriver:
 
     def run(self, req: ReviewRequest) -> RunResult:
         run_key = compute_run_key(req.repo, req.pr, req.trigger_id)
-        emit(
-            "run.start", run_key=run_key, repo=req.repo, pr=req.pr, dry_run=req.dry_run
-        )
+        emit("run.start", run_key=run_key, repo=req.repo, pr=req.pr)
 
         lease = acquire_lease(
             self._cfg.state_dir,
@@ -95,7 +92,7 @@ class SessionDriver:
                 exit_code=ExitCode.OK, detail={"skipped": True, "prior": prior}
             )
 
-        decide = dry_run_guard(self._decision_fn) if req.dry_run else self._decision_fn
+        decide = self._decision_fn
         deadline = Deadline(self._cfg.run_deadline_s)
         result = RunResult(exit_code=ExitCode.OK)
 
@@ -415,12 +412,6 @@ def _build_prompt(req: ReviewRequest) -> str:
             '"summary" (string), and "findings" (array of {severity, note}).'
         ),
     ]
-    if req.dry_run:
-        lines.append("")
-        lines.append(
-            "DRY RUN: do not post any comment or review to GitHub and do not "
-            "push, merge, or otherwise mutate anything. Produce the verdict only."
-        )
     return "\n".join(lines)
 
 

--- a/.github/seidroid/xreview/driver/policy.py
+++ b/.github/seidroid/xreview/driver/policy.py
@@ -120,21 +120,3 @@ def best_effort_readonly_policy(elicitation: Elicitation) -> Action:
 def fail_closed_policy(_elicitation: Elicitation) -> Action:
     """Decline everything. The safest possible default."""
     return "decline"
-
-
-def dry_run_guard(inner: DecisionFn) -> DecisionFn:
-    """Wrap a policy so it can only accept a permitted-by-identity tool.
-
-    The same identity set applies in both modes, so this wrapper keeps a dry
-    run from accepting anything ``inner`` might, regardless of ``inner``. It
-    does NOT make the agent read-only: ``Bash`` is permitted in both modes, and
-    dry-run gates only the *driver's* verdict post — not the agent's own
-    ``gh``/``git`` writes through its vended token (see the module docstring).
-    """
-
-    def decide(elicitation: Elicitation) -> Action:
-        if elicitation.tool_name not in _PERMITTED_TOOLS:
-            return "decline"
-        return inner(elicitation)
-
-    return decide

--- a/.github/seidroid/xreview/tools/seidroid-xreview.yml
+++ b/.github/seidroid/xreview/tools/seidroid-xreview.yml
@@ -4,8 +4,7 @@ name: seidroid xreview
 # trigger only fires from the default branch), then:
 #   1. Pin both refs below to a uci release tag or commit SHA (never a moving tag).
 #   2. Set the OMNIGENT_M2M_CLIENT_SECRET repo (or org) secret.
-#   3. Leave the SEIDROID_XREVIEW_DRY_RUN repo variable unset until you have watched a
-#      run (unset -> dry-run). Then comment `seidroid xreview` (or `... --dry-run`) on a
+#   3. Comment `seidroid xreview` on a
 #      PR to invoke.
 # The heavy lifting is the reusable workflow in sei-protocol/uci at
 # .github/workflows/seidroid-xreview.yml; this wrapper only wires the trigger.

--- a/.github/workflows/seidroid-xreview.yml
+++ b/.github/workflows/seidroid-xreview.yml
@@ -5,8 +5,7 @@ run-name: UCI / seidroid xreview
 # issue_comment trigger and calls this with `uses:` (template:
 # .github/seidroid/xreview/tools/seidroid-xreview.yml). Flow: comment
 # `seidroid xreview` on a PR -> trusted-commenter gate -> drive one managed sei-droid
-# omnigent session over the PR -> post one sticky verdict (or, in dry-run, write it to
-# the job summary and post nothing) -> tear the session down.
+# omnigent session over the PR -> post one sticky verdict -> tear the session down.
 #
 # The driver is fetched from sei-protocol/uci at `uci-ref` and run in-line, so a caller
 # updates by bumping the pinned ref — it never copies the review logic.
@@ -48,34 +47,24 @@ jobs:
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) }}
     outputs:
       should_run: ${{ steps.parse.outputs.should_run }}
-      dry_run: ${{ steps.parse.outputs.dry_run }}
       pr_number: ${{ steps.parse.outputs.pr_number }}
       comment_id: ${{ steps.parse.outputs.comment_id }}
     steps:
       - id: parse
         env:
           BODY: ${{ github.event.comment.body }}
-          # Reviewed repo's safety toggle. Unset -> dry-run (fail safe). Set to
-          # 'false' in Settings -> Secrets and variables -> Actions -> Variables
-          # to enable real posts.
-          REPO_DRY_RUN: ${{ vars.SEIDROID_XREVIEW_DRY_RUN }}
         run: |
           set -euo pipefail
           cmd="$(printf '%s' "$BODY" | tr -d '\r')"
-          # Match a LINE reading exactly `seidroid xreview` (optionally `--dry-run`)
-          # and CAPTURE it; the captured line — not the whole body — is what the
-          # --dry-run check below reads, so prose mentioning `--dry-run` elsewhere
-          # in the comment cannot force dry-run.
-          cmdline="$(printf '%s\n' "$cmd" | grep -m1 -E '^[[:space:]]*seidroid[[:space:]]+xreview([[:space:]]+--dry-run)?[[:space:]]*$' || true)"
+          # Require a LINE reading exactly `seidroid xreview`. Anchoring the match to a
+          # whole line is what keeps a comment that merely quotes or discusses the
+          # command from triggering a review.
+          cmdline="$(printf '%s\n' "$cmd" | grep -m1 -E '^[[:space:]]*seidroid[[:space:]]+xreview[[:space:]]*$' || true)"
           if [ -z "$cmdline" ]; then
             echo "should_run=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "should_run=true" >> "$GITHUB_OUTPUT"
-          # dry-run = the flag ON THE COMMAND LINE, or the repo default. Unset -> TRUE.
-          dry="${REPO_DRY_RUN:-true}"
-          if printf '%s' "$cmdline" | grep -qE -- '--dry-run'; then dry=true; fi
-          echo "dry_run=$dry" >> "$GITHUB_OUTPUT"
           echo "pr_number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
           # The comment id becomes the driver's per-trigger run key, so a
           # re-delivered comment adopts the same session rather than driving a
@@ -163,7 +152,6 @@ jobs:
           DRIVER_PYTHON: ${{ steps.runtime.outputs.python }}
           OMNIGENT_BASE_URL: ${{ inputs.omnigent-base-url }}
           OMNIGENT_API_TOKEN: ${{ steps.token.outputs.token }}
-          DRY_RUN: ${{ needs.guard.outputs.dry_run }}
           REPO: ${{ github.repository }}
           PR: ${{ needs.guard.outputs.pr_number }}
           TRIGGER_ID: ${{ needs.guard.outputs.comment_id }}
@@ -176,7 +164,6 @@ jobs:
           # exact opt-in 'false' runs dry. --trigger-id scopes the run key to this
           # comment so a re-fire adopts rather than resurrects.
           args=("$REPO" "$PR" --out verdict.md)
-          if [ "$DRY_RUN" != "false" ]; then args+=(--dry-run); fi
           if [ -n "${TRIGGER_ID:-}" ]; then args+=(--trigger-id "$TRIGGER_ID"); fi
           set +e
           PYTHONPATH="$DRIVER_ROOT" XREVIEW_STATE_DIR="$RUNNER_TEMP/seidroid-state" \
@@ -198,10 +185,10 @@ jobs:
           fi
 
       - name: Post verdict (sticky upsert)
-        # Post ONLY in real-post mode AND only when a real verdict was produced. Keying
-        # on verdict_produced, not the exit code, so a teardown-only failure still posts
-        # a valid verdict and a no-verdict run never upserts a placeholder.
-        if: ${{ needs.guard.outputs.dry_run == 'false' && steps.drive.outputs.verdict_produced == 'true' }}
+        # Post only when a real verdict was produced. Keying on verdict_produced, not
+        # the exit code, so a teardown-only failure still posts a valid verdict and a
+        # no-verdict run never upserts a placeholder.
+        if: ${{ steps.drive.outputs.verdict_produced == 'true' }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -220,12 +207,3 @@ jobs:
           else
             gh api -X POST "repos/$REPO/issues/$PR/comments" -f body="$body" >/dev/null
           fi
-
-      - name: Dry-run summary (posts nothing)
-        # Surface the outcome for every non-real-post run (but not on cancellation).
-        if: ${{ !cancelled() && needs.guard.outputs.dry_run != 'false' }}
-        shell: bash
-        run: |
-          { echo "## sei-droid xreview (dry-run, not posted)"; echo; \
-            cat verdict.md 2>/dev/null || echo "_(no verdict produced — see the Drive step logs)_"; \
-          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What

Removes dry-run from `seidroid xreview` entirely. Posting the verdict to the PR becomes the only behaviour.

## Why

Dry-run suppressed the driver's verdict post and nothing else. It still claimed a runner and created a full sandbox session, so it was never a cheap preview — and because the repo variable defaults to dry (`${REPO_DRY_RUN:-true}`), every adopting repo needed a per-repo opt-in before it could do the one thing the feature is for.

It also read as a safety mode without being one. `policy.dry_run_guard`'s own docstring said so:

> It does **NOT** make the agent read-only: `Bash` is permitted in both modes, and dry-run gates only the *driver's* verdict post — not the agent's own `gh`/`git` writes through its vended token.

The prompt did append a `DRY RUN: do not post ... do not push, merge, or otherwise mutate anything` instruction, but that is a request to a model rather than a control, and it never applied in the mode repos actually run in.

## What changed

| Removed | Where |
|---|---|
| `SEIDROID_XREVIEW_DRY_RUN` repo variable + `${REPO_DRY_RUN:-true}` resolution | `.github/workflows/seidroid-xreview.yml` |
| `--dry-run` command flag in the trigger regex | same |
| guard's `dry_run` output, drive step's `DRY_RUN` env + `--dry-run` arg | same |
| "Dry-run summary (posts nothing)" step | same |
| `--dry-run` CLI arg, `ReviewRequest.dry_run` | `driver/__main__.py`, `driver/driver.py` |
| `DRY RUN:` prompt instruction | `driver/driver.py` |
| `dry_run_guard` | `driver/policy.py` |

Posting is now gated on `steps.drive.outputs.verdict_produced == 'true'` alone, which it already was in addition to the mode.

## Two properties deliberately preserved

**The exact-line trigger match.** Previously described in terms of stopping prose from forcing dry-run; it stands on its own and is kept, so a comment that quotes or discusses `seidroid xreview` still does not trigger a review.

**The untrusted-content preconditions.** These never depended on dry-run — the risk belongs to running the agent at all — so they are kept and promoted rather than trimmed alongside the mode. The section is retitled "Before pointing this at untrusted content" and now states plainly that no review mode mitigates it, which the old framing arguably obscured by offering dry-run as a first step. The precondition that was purely about enabling posts ("a successful dry run has completed") is the only one dropped.

The safety-properties list loses the "Dry-run is the default" bullet and gains the one that is now true: a run that produces no verdict posts nothing.

## Breaking

The driver CLI drops `--dry-run` and the workflow drops the guard's `dry_run` output, so this wants a version bump. `sei-protocol/platform` pins `uci v0.0.14` by commit SHA in two places (`uses:` and `with: uci-ref`) and needs a companion bump once this is tagged — I have that PR ready to open against the new tag.

## Verification

- Driver selftest: **ALL PASS** (18 checks)
- `ruff check driver/`: clean
- `ruff format --check`: clean on the three files touched. `driver/tests/selftest.py` has a pre-existing deviation on `main` and is left alone.
- Both workflow YAMLs parse, jobs intact (`guard`, `xreview`).

Neither the selftest nor ruff is currently wired into CI, so these were run locally.