### PR TITLE
Run seidroid xreview from the released Go driver

### DIFF
--- a/.github/workflows/seidroid-xreview.yml
+++ b/.github/workflows/seidroid-xreview.yml
@@ -1,0 +1,168 @@
+name: seidroid xreview
+run-name: UCI / seidroid xreview
+
+# Reusable, comment-triggered agentic PR review. A thin caller in the reviewed repo
+# wires the issue_comment trigger and calls this with `uses:`. Flow: comment
+# `seidroid xreview` on a PR -> trusted-commenter gate -> drive one managed sei-droid
+# omnigent session over the PR -> post one sticky verdict.
+#
+# The review itself is sei-agent-driver, installed at `driver-version` from
+# sei-protocol/sei-internal-skills, which is public. A caller updates by bumping the
+# pinned `uses:` ref; the driver version travels with it, so one ref fixes both the
+# workflow and the binary it runs.
+
+on:
+  workflow_call:
+    inputs:
+      driver-version:
+        description: "sei-agent-driver release to install. Bump with the pinned uses: ref."
+        required: false
+        type: string
+        default: 'v0.1.0'
+      runs-on:
+        description: "Runner label for the review job."
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+      omnigent-base-url:
+        description: "omnigent base URL. Reached over https, so no in-cluster runner is needed."
+        required: false
+        type: string
+        default: 'https://seigent.dev.platform.sei.io'
+    secrets:
+      OMNIGENT_M2M_CLIENT_SECRET:
+        description: "omnigent client-credentials secret. The driver exchanges it for a session bearer."
+        required: true
+
+permissions: {}
+
+jobs:
+  guard:
+    # Cheap allowlist and command parse on a hosted runner, no secrets, before any
+    # review work spins up. The author_association gate is the trust boundary: only
+    # OWNER/MEMBER/COLLABORATOR can fire it, so an untrusted PR author cannot.
+    name: Guard
+    runs-on: ubuntu-latest
+    permissions: {}
+    if: >-
+      ${{ github.event.issue.pull_request != null &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) }}
+    outputs:
+      should_run: ${{ steps.parse.outputs.should_run }}
+      pr_number: ${{ steps.parse.outputs.pr_number }}
+      comment_id: ${{ steps.parse.outputs.comment_id }}
+    steps:
+      - id: parse
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          set -euo pipefail
+          cmd="$(printf '%s' "$BODY" | tr -d '\r')"
+          # Require a LINE reading exactly `seidroid xreview`. Anchoring the match to a
+          # whole line is what keeps a comment that merely quotes or discusses the
+          # command from triggering a review.
+          cmdline="$(printf '%s\n' "$cmd" | grep -m1 -E '^[[:space:]]*seidroid[[:space:]]+xreview[[:space:]]*$' || true)"
+          if [ -z "$cmdline" ]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # The comment id becomes the driver's per-trigger id, so a re-delivered
+          # comment adopts the same session rather than driving a new turn.
+          {
+            echo "should_run=true"
+            echo "pr_number=${{ github.event.issue.number }}"
+            echo "comment_id=${{ github.event.comment.id }}"
+          } >> "$GITHUB_OUTPUT"
+
+  xreview:
+    name: Review
+    needs: guard
+    if: needs.guard.outputs.should_run == 'true'
+    # Exactly one review per PR: a newer `seidroid xreview` cancels an in-flight one,
+    # so there are never two posters. Job-level, so the group is entered only when a
+    # real command runs.
+    concurrency:
+      group: seidroid-xreview-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    runs-on: ${{ inputs.runs-on }}
+    # Above the driver's own run deadline, so a slow-but-valid review is never
+    # hard-killed mid-turn, which would end it with no annotation saying why.
+    timeout-minutes: 40
+    permissions:
+      pull-requests: write   # upsert the one sticky verdict comment
+      contents: read         # read PR metadata
+    env:
+      # Installed here rather than left to the runner image's GOPATH, so both steps
+      # name one path and neither shells out to `go env`.
+      GOBIN: ${{ github.workspace }}/.driver-bin
+    steps:
+      # Pinned rather than taking the runner image's Go, which moves under us and
+      # only has to satisfy the module's floor by luck.
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      # Public module, so no credential and no GOPRIVATE. The version reference is
+      # plain: the driver is a nested module, and its path-prefixed tag is what
+      # resolution consumes rather than what is typed here.
+      - name: Install the driver
+        env:
+          DRIVER_VERSION: ${{ inputs.driver-version }}
+        run: |
+          set -euo pipefail
+          go install "github.com/sei-protocol/sei-internal-skills/sei-agent-driver/cmd/sei-agent-driver@${DRIVER_VERSION}"
+          "$GOBIN/sei-agent-driver" --version
+
+      - name: Review
+        id: drive
+        env:
+          OMNIGENT_BASE_URL: ${{ inputs.omnigent-base-url }}
+          OMNIGENT_M2M_CLIENT_ID: sei-droid
+          OMNIGENT_M2M_CLIENT_SECRET: ${{ secrets.OMNIGENT_M2M_CLIENT_SECRET }}
+          # The driver declines every permission prompt it is not told to accept, so
+          # without this the agent is refused the shell it needs to read the diff and
+          # reviews nothing. Matched on tool_name, not policy_name: the deployment
+          # sends one policy name for every native request, so allowing that would
+          # accept every tool call the agent asks for.
+          XREVIEW_ALLOW_TOOLS: Bash,Read
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ needs.guard.outputs.pr_number }}
+          TRIGGER_ID: ${{ needs.guard.outputs.comment_id }}
+        run: |
+          set -uo pipefail
+          "$GOBIN/sei-agent-driver" xreview "$REPO" "$PR" \
+            --out verdict.md --trigger-id "$TRIGGER_ID"
+          rc=$?
+          # Gates on whether a verdict was PRODUCED, not on the exit code: a
+          # teardown-only failure still publishes, and a no-verdict run never posts a
+          # placeholder.
+          if [ -s verdict.md ]; then
+            echo "verdict_produced=true" >> "$GITHUB_OUTPUT"
+            if [ "$rc" -ne 0 ]; then
+              echo "::warning::driver exited $rc but produced a verdict; see the logs"
+            fi
+          else
+            echo "verdict_produced=false" >> "$GITHUB_OUTPUT"
+            echo "::error::driver produced no verdict (exit $rc)"
+            exit "$rc"
+          fi
+
+      - name: Post verdict (sticky upsert)
+        if: ${{ steps.drive.outputs.verdict_produced == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MARKER: "<!-- seidroid-xreview -->"
+          REPO: ${{ github.repository }}
+          PR: ${{ needs.guard.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          body="$MARKER"$'\n'"$(cat verdict.md)"
+          # One bot comment per PR: find by marker, then PATCH, else POST.
+          id="$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+                --jq "map(select(.body | startswith(\"$MARKER\"))) | .[0].id // empty")"
+          if [ -n "$id" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$id" -f body="$body" >/dev/null
+          else
+            gh api -X POST "repos/$REPO/issues/$PR/comments" -f body="$body" >/dev/null
+          fi


### PR DESCRIPTION
`seidroid-xreview.yml` is gone from main, but sei-chain and platform still pin the
v0.0.15 commit that carries it. What they pin sets up a Python venv and exits at
`command -v python3 >/dev/null || exit 1`, so neither repo has been getting a review.
This restores the workflow with the review itself moved to `sei-agent-driver`.

## What replaces what

The driver is installed from `sei-protocol/sei-internal-skills`, which is public, so
there is no credential and no `GOPRIVATE`. Four steps become two:

| was | now |
|---|---|
| sparse checkout of this repo for the driver source | `go install` at a pinned version |
| python venv + `httpx` install | gone |
| `curl` exchange at `/oauth/token` for a bearer | gone; the driver mints its own |
| `python -m driver` | the binary |

Dropping the curl exchange also gets the token out of a step output, where every
later step in the job could read it. The driver takes the M2M client and mints
in-process.

## One ref pins both

`driver-version` travels with the pinned `uses:` ref, so bumping a caller moves the
workflow and the binary together. The skew those callers are in today — a pinned
commit whose file no longer exists on main — is the failure this shape prevents.

## The endpoint

`platform` `clusters/dev/seigent/httproute.yaml` routes `seigent.dev.platform.sei.io`
through the Istio https listener to the omnigent Service, so the job no longer has
to be inside the mesh. `runs-on` defaults to a hosted runner, which also removes the
pinned jq and gh bootstrap the ARC image needed because it ships neither.

## XREVIEW_ALLOW_TOOLS

Set, and load-bearing. The driver declines every permission prompt it is not told to
accept, so without it the agent is refused the shell it reads the diff with and
reports on nothing. Matched on `tool_name` rather than `policy_name`, because this
deployment sends one policy name for every native permission request — allowing that
value would accept every tool call the agent asks for.

## Kept as they were

The trusted-commenter guard, the whole-line command match, the per-PR concurrency
group, the sticky comment upsert, and gating the post on whether a verdict was
produced rather than on the exit code. Go is pinned rather than inherited from the
runner image, which only satisfies the module's floor by luck.

## Callers

`uci-ref` is removed, since nothing is fetched from this repo any more. The two thin
callers drop that input when they bump their pinned ref. Nothing else changes for
them: they still pass `OMNIGENT_M2M_CLIENT_SECRET` and nothing else.

## Verification

actionlint clean, and shellcheck clean over the extracted run blocks. `go install` of
the pinned version was confirmed to work with no credentials in the environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)