### PR TITLE
Enable AI review and assistance on UCI

### DIFF
--- a/.github/workflows/ai-assist.yml
+++ b/.github/workflows/ai-assist.yml
@@ -1,0 +1,22 @@
+name: AI Assistant
+on:
+  issue_comment:
+    types: [ created ]
+  pull_request_review_comment:
+    types: [ created ]
+  pull_request_review:
+    types: [ submitted ]
+jobs:
+  assistant:
+    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.17
+    uses: sei-protocol/uci/.github/workflows/ai-assistant.yml@1d50ef2bd27c695493f254c3037eb6b78f9bb85f
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    secrets: inherit
+    with:
+      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.17
+      uci-ref: 1d50ef2bd27c695493f254c3037eb6b78f9bb85f
+      allowed-team: 'sei-protocol/sei-core'

--- a/.github/workflows/ai-review-self.yml
+++ b/.github/workflows/ai-review-self.yml
@@ -1,0 +1,26 @@
+name: AI Review
+on:
+  pull_request:
+    types: [ opened, ready_for_review, synchronize, reopened ]
+  issue_comment:
+    types: [ created ]
+  pull_request_review_comment:
+    types: [ created ]
+  pull_request_review:
+    types: [ submitted ]
+jobs:
+  ai-review:
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
+    # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.17
+    uses: sei-protocol/uci/.github/workflows/ai-review.yml@1d50ef2bd27c695493f254c3037eb6b78f9bb85f
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
+      id-token: write
+    secrets: inherit
+    with:
+      # See: https://github.com/sei-protocol/uci/releases/tag/v0.0.17
+      uci-ref: 1d50ef2bd27c695493f254c3037eb6b78f9bb85f
+      allowed-team: 'sei-protocol/sei-core'
+      enable-cursor: false # Disabled for now since there is a dedicated Bugbot flow built into Cursor currently enabled on repo.


### PR DESCRIPTION
## Summary
- add the same SHA-pinned UCI v0.0.17 assistant and review callers used by [runbooks #115](https://github.com/sei-protocol/runbooks/pull/115)
- gate requests to `sei-protocol/sei-core`, support explicit `@seidroid review` requests, and keep Cursor disabled to avoid duplicating Bugbot
- name the review caller `ai-review-self.yml` because `ai-review.yml` is the existing published reusable workflow

## Test plan
- [x] Compare both caller workflows with the runbooks configuration
- [x] Run `actionlint` on both new workflows
- [x] Run `git diff --check`

Made with [Cursor](https://cursor.com)