### PR TITLE
Fix concuccency control on AI review trigger by comment

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -104,20 +104,14 @@ on:
         type: number
         default: 15
 
-permissions: {}
+permissions: { }
 
 concurrency:
-  # Collapse automatic reviews after rapid pushes, but isolate each explicit request so
-  # a push or another comment cannot cancel it before preflight processes it.
-  group: >-
-    ai-review-${{ github.event.pull_request.number || github.event.issue.number }}-${{
-      github.event_name == 'pull_request' &&
-      'automatic' ||
-      github.event.comment.id ||
-      github.event.review.id ||
-      github.run_id
-    }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Serialize reviews per PR so automatic and explicit runs cannot race when posting,
+  # dismissing previous findings, or updating the AI Review check.
+  group: ai-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
+  queue: max
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -135,18 +129,21 @@ jobs:
           github.event_name == 'issue_comment' &&
           github.event.issue.pull_request &&
           github.event.comment.user.type != 'Bot' &&
-          contains(github.event.comment.body, format('{0} review', inputs.trigger-phrase))
+          contains(github.event.comment.body, inputs.trigger-phrase) &&
+          contains(github.event.comment.body, 'review')
         ) ||
         (
           github.event_name == 'pull_request_review_comment' &&
           github.event.comment.user.type != 'Bot' &&
-          contains(github.event.comment.body, format('{0} review', inputs.trigger-phrase))
+          contains(github.event.comment.body, inputs.trigger-phrase) &&
+          contains(github.event.comment.body, 'review')
         ) ||
         (
           github.event_name == 'pull_request_review' &&
           github.event.review.user.type != 'Bot' &&
           github.event.review.body &&
-          contains(github.event.review.body, format('{0} review', inputs.trigger-phrase))
+          contains(github.event.comment.body, inputs.trigger-phrase) &&
+          contains(github.event.comment.body, 'review')
         )
       }}
     permissions:
@@ -692,7 +689,7 @@ jobs:
   # ---------------------------------------------------------------------------
   claude_review:
     name: Claude
-    needs: [preflight, codex_review, cursor_review]
+    needs: [ preflight, codex_review, cursor_review ]
     runs-on: ${{ inputs.runs-on }}
     # `!cancelled()` lets this run when a scout is toggled off or fails. `should_run`
     # carries the preflight's draft/label/history/authorization decision to every pass.
@@ -1085,7 +1082,7 @@ jobs:
 
   complete_review_reaction:
     name: Complete review reaction
-    needs: [preflight, codex_review, cursor_review, claude_review]
+    needs: [ preflight, codex_review, cursor_review, claude_review ]
     if: ${{ always() && needs.preflight.outputs.reaction_subject_id != '' }}
     runs-on: ${{ inputs.runs-on }}
     permissions:

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -107,9 +107,16 @@ on:
 permissions: {}
 
 concurrency:
-  # Pull-request updates supersede in-flight work. Comment events never cancel an active
-  # review: concurrency is acquired before preflight can reject unrelated comments.
-  group: ai-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  # Collapse automatic reviews after rapid pushes, but isolate each explicit request so
+  # a push or another comment cannot cancel it before preflight processes it.
+  group: >-
+    ai-review-${{ github.event.pull_request.number || github.event.issue.number }}-${{
+      github.event_name == 'pull_request' &&
+      'automatic' ||
+      github.event.comment.id ||
+      github.event.review.id ||
+      github.run_id
+    }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
@@ -128,18 +135,18 @@ jobs:
           github.event_name == 'issue_comment' &&
           github.event.issue.pull_request &&
           github.event.comment.user.type != 'Bot' &&
-          contains(github.event.comment.body, inputs.trigger-phrase)
+          contains(github.event.comment.body, format('{0} review', inputs.trigger-phrase))
         ) ||
         (
           github.event_name == 'pull_request_review_comment' &&
           github.event.comment.user.type != 'Bot' &&
-          contains(github.event.comment.body, inputs.trigger-phrase)
+          contains(github.event.comment.body, format('{0} review', inputs.trigger-phrase))
         ) ||
         (
           github.event_name == 'pull_request_review' &&
           github.event.review.user.type != 'Bot' &&
           github.event.review.body &&
-          contains(github.event.review.body, inputs.trigger-phrase)
+          contains(github.event.review.body, format('{0} review', inputs.trigger-phrase))
         )
       }}
     permissions:


### PR DESCRIPTION
Refine the concurrency control to avoid premature cancellation of jobs.

Refine the if to avoid unnecessary trigger for irrelevant prompts in ai review.

Fixes PLT-1045
